### PR TITLE
Resolve Seeding Problems

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,7 +21,7 @@ recipes.each do |r|
   dish = Recipe.create(name: r['Recipe Name'].titleize, instructions: r['instructions'], calories: Faker::Number.between(from: 100, to: 1200), image: r['image'], description: r['descriptor'])
 
   ethnicity = Category.find_or_create_by(name: "#{r['ethnicity'].titleize}")
-  catageory = Category.find_or_create_by(name: "#{r['category'].titleize}")
+  category = Category.find_or_create_by(name: "#{r['category'].titleize}")
 
   ethnicity.recipe << dish
   category.recipe << dish

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,12 +19,17 @@ recipes = CSV.parse(csv_data, headers: true, encoding: 'utf-8')
 
 recipes.each do |r|
   dish = Recipe.create(name: r['Recipe Name'].titleize, instructions: r['instructions'], calories: Faker::Number.between(from: 100, to: 1200), image: r['image'], description: r['descriptor'])
-  dish.category.create(name: "#{r['ethnicity'].titleize}")
-  dish.category.create(name: "#{r['category'].titleize}")
+
+  ethnicity = Category.find_or_create_by(name: "#{r['ethnicity'].titleize}")
+  catageory = Category.find_or_create_by(name: "#{r['category'].titleize}")
+
+  ethnicity.recipe << dish
+  category.recipe << dish
 
   r['ingredients'].split(',').each do |i|
     stripped_ingredient = i.strip.titleize
-    dish.ingredient.create(name:stripped_ingredient, count:Faker::Number.between(from: 1, to: 10))
+    ingredient = Ingredient.find_or_create_by(name: stripped_ingredient)
+    ingredient.recipe << dish
   end
 end
 


### PR DESCRIPTION
The issue encountered was that for some recipes, the categories and ingredients are not populated. The root cause of the problem turned out to be since the name of both the categories and ingredients have uniqueness validation, calling create every time will not work. The fix is to first retrieve the category and ingredient through AR and then add the recipe to the associated collections between Recipes and Categories, and Recipes and Ingredients. 